### PR TITLE
Fixing the date utils locale to use the currently set one

### DIFF
--- a/Sources/CalendarView/Utils/Date+Extension.swift
+++ b/Sources/CalendarView/Utils/Date+Extension.swift
@@ -14,7 +14,6 @@ extension Date {
     public var weekDayName: String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "EEEE"
-        dateFormatter.locale = Locales.vietnamese.toLocale()
         return dateFormatter.string(from: self)
     }
 
@@ -22,7 +21,6 @@ extension Date {
     public var weekDayShortName: String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "EE"
-        dateFormatter.locale = Locales.vietnamese.toLocale()
         return dateFormatter.string(from: self)
     }
 
@@ -30,7 +28,6 @@ extension Date {
     public var dayName: String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "d"
-        dateFormatter.locale = Locales.vietnamese.toLocale()
         return dateFormatter.string(from: self)
     }
 


### PR DESCRIPTION
## CalendarView SwiftUI

**Reason:**
The short names were using Vietnamese Locale instead of the current locale of the device

**Changes:**
Removed the specific utilisation of the Vietnamese locale

**Impact:**
Can now use the date extensions in whichever language you are using on your device

- [ X] Build Passing?
- [X ] Build On Real Device?
